### PR TITLE
index.html: load everything over https

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
 	<title>CodeMirror Spell Checker by NextStepWebs</title>
 	<meta name="viewport" content="width=device-width, initial-scale=1">
 	<link rel="stylesheet" type="text/css" href="stylesheets/normalize.css" media="screen">
-	<link href='http://fonts.googleapis.com/css?family=Open+Sans:400,700' rel='stylesheet' type='text/css'>
+	<link href='https://fonts.googleapis.com/css?family=Open+Sans:400,700' rel='stylesheet' type='text/css'>
 	<link rel="stylesheet" type="text/css" href="stylesheets/stylesheet.css" media="screen">
 	<link rel="stylesheet" type="text/css" href="stylesheets/github-light.css" media="screen">
   </head>
@@ -37,8 +37,8 @@ The backdrop mode is [GitHub Flavored Markdown](https://help.github.com/articles
 	<script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.4.0/mode/markdown/markdown.min.js"></script>
 	<script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.4.0/addon/mode/overlay.min.js"></script>
 	<script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.4.0/mode/gfm/gfm.min.js"></script>
-	<link rel="stylesheet" href="http://cdn.jsdelivr.net/codemirror.spell-checker/latest/spell-checker.min.css">
-	<script src="http://cdn.jsdelivr.net/codemirror.spell-checker/latest/spell-checker.min.js"></script>
+	<link rel="stylesheet" href="https://cdn.jsdelivr.net/codemirror.spell-checker/latest/spell-checker.min.css">
+	<script src="https://cdn.jsdelivr.net/codemirror.spell-checker/latest/spell-checker.min.js"></script>
 	
 	<script>
 	CodeMirror.fromTextArea(document.getElementById("demo1"), {


### PR DESCRIPTION
Avoids mixed-content errors if loading the demo over https
[which happens automatically for HTTPS Everywhere users;
background on Github Pages https: https://konklone.com/post/github-pages-now-sorta-supports-https-so-use-it]
